### PR TITLE
Add pdflib9 support for Alpine Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ go install -tags 'pdflib8'
 go install -tags 'pdflib9' 
 ```
 
+#### Building for Alpine Linux
+
+```bash
+go build -tags 'alpine' ... 
+```
+
 #### Requirements
 
 - Golang >= 1.5

--- a/pdflib9_alpine.go
+++ b/pdflib9_alpine.go
@@ -14,9 +14,10 @@
 
 // +build pdflib9 !pdflib8
 // +build cgo
+// +build alpine
 
 package pdflib
 
 // #cgo CFLAGS: -Iinclude
-// #cgo LDFLAGS: -L${SRCDIR}/lib -lpdf9-amd64-linux -lm
+// #cgo LDFLAGS: -L${SRCDIR}/lib -lpdf9-alpine -lm
 import "C"

--- a/pdflib9_amd64.go
+++ b/pdflib9_amd64.go
@@ -1,0 +1,22 @@
+// Copyright © 2016 Abcum Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this info except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build pdflib9 !pdflib8
+// +build cgo
+
+package pdflib
+
+// #cgo CFLAGS: -Iinclude
+// #cgo LDFLAGS: -L${SRCDIR}/lib -lpdf9-amd64-linux -lm
+import "C"

--- a/pdflib9_linux.go
+++ b/pdflib9_linux.go
@@ -14,6 +14,7 @@
 
 // +build pdflib9 !pdflib8
 // +build cgo
+// +build !alpine
 
 package pdflib
 


### PR DESCRIPTION
Added amd64 architecture support to make the library work in Alpine Linux.